### PR TITLE
Fatal error in PHP 8

### DIFF
--- a/class-plugin-theme-review-request.php
+++ b/class-plugin-theme-review-request.php
@@ -190,13 +190,13 @@ class Prefix_Modules_Reviews {
 
 		$trigger = self::triggers( $group, $code );
 
-		if(empty($key)){
-            $return = $trigger;
-        }elseif(isset($trigger[$key])){
-            $return = $trigger[$key];
-        }else {
-           	$return = false;
-        }
+		if( empty( $key ) ) {
+			$return = $trigger;
+		} elseif ( isset( $trigger[ $key ] ) ){
+			$return = $trigger[ $key ];
+		} else {
+			$return = false;
+		}
         
 		return $return;
 	}
@@ -337,15 +337,15 @@ class Prefix_Modules_Reviews {
 				return false;
 			}
 
-			if (!isset($code)) {
-                $return = $triggers[$group];
-            } elseif (isset($triggers[$group]['triggers'][$code])) {
-                $return = $triggers[$group]['triggers'][$code];
-            } else {
-                $return = false;
-            }
+			if ( ! isset( $code ) ) {
+				$return = $triggers[ $group ];
+			} elseif ( isset( $triggers[ $group ]['triggers'][ $code ] ) ) {
+				$return = $triggers[ $group ]['triggers'][ $code ];
+			} else {
+				$return = false;
+			}
 
-            return $return;
+			return $return;
 		}
 
 		return $triggers;

--- a/class-plugin-theme-review-request.php
+++ b/class-plugin-theme-review-request.php
@@ -190,7 +190,15 @@ class Prefix_Modules_Reviews {
 
 		$trigger = self::triggers( $group, $code );
 
-		return empty( $key ) ? $trigger : ( isset( $trigger[ $key ] ) ? $trigger[ $key ] : false );
+		if(empty($key)){
+            $return = $trigger;
+        }elseif(isset($trigger[$key])){
+            $return = $trigger[$key];
+        }else {
+           	$return = false;
+        }
+        
+		return $return;
 	}
 
 	/**
@@ -329,7 +337,15 @@ class Prefix_Modules_Reviews {
 				return false;
 			}
 
-			return ! isset( $code ) ? $triggers[ $group ] : isset( $triggers[ $group ]['triggers'][ $code ] ) ? $triggers[ $group ]['triggers'][ $code ] : false;
+			if (!isset($code)) {
+                $return = $triggers[$group];
+            } elseif (isset($triggers[$group]['triggers'][$code])) {
+                $return = $triggers[$group]['triggers'][$code];
+            } else {
+                $return = false;
+            }
+
+            return $return;
 		}
 
 		return $triggers;


### PR DESCRIPTION
Hi @danieliser, 3 ternary operator trigger Fatal error in PHP 8

`"PHP Fatal error: Unparenthesizeda ? b : c ? d : eis not supported. Use either(a ? b : c) ? d : eora ? b : (c ? d : e)in plugins/WP-Product-In-Dash-Review-Requests/class-plugin-theme-review-request.php on line 193 and line 322`